### PR TITLE
Code changes to build framework without JDBC dependency.

### DIFF
--- a/framework/src/main/java/org/apache/drill/test/framework/ConnectionPool.java
+++ b/framework/src/main/java/org/apache/drill/test/framework/ConnectionPool.java
@@ -35,12 +35,12 @@ public class ConnectionPool implements AutoCloseable {
 
   public ConnectionPool(Properties connectionProperties) {
     this.connectionProperties = connectionProperties;
-    try {
-      Class.forName(DrillTestDefaults.JDBC_DRIVER);
-    } catch (ClassNotFoundException e) {
-      e.printStackTrace();
-      System.exit(-1);
-    }
+    // try {
+      // Class.forName(DrillTestDefaults.JDBC_DRIVER);
+    // } catch (ClassNotFoundException e) {
+      // e.printStackTrace();
+      // System.exit(-1);
+    // }
     //Driver.load();
     connections = new HashMap<>();
   }


### PR DESCRIPTION
Disable connection pools, which use JDBC driver.