### PR TITLE
Add before-run.sh script to run some commands before starting tests.

### DIFF
--- a/before-run.sh
+++ b/before-run.sh
@@ -1,0 +1,29 @@
+
+# set -x
+
+password=$(kubectl get secret system -n dataplatform -o yaml | grep MAPR_PASSWORD | head -1 | awk '{print $2}' | base64 --decode)
+# password="mapr"
+
+errors=0
+
+for i in $(kubectl get pods -n dataplatform | grep -v NAME | grep -v init | awk '{print $1}')
+do
+  ret=$(kubectl exec -i $i -n dataplatform -- bash -c "echo \"$password\" | maprlogin password -user mapr" 2>&1)
+  if ! { [[ $ret == "MapR credentials of user 'mapr' for cluster 'dataplatform' are written to '/tmp/maprticket_5000'" ]] ; }
+  then
+    echo "cannot get mapr ticket for " $i
+    echo $ret
+    ((errors++))
+  fi
+done
+
+ret=$(kubectl exec -i -n internaltenant `kubectl get pods -n internaltenant|grep tenantcli|awk '{print $1}'` -- bash -c "echo \"$password\" | maprlogin password -user mapr" 2>&1)
+if ! { [[ $ret == "MapR credentials of user 'mapr' for cluster 'dataplatform' are written to '/tmp/maprticket_5000'" ]] ; }
+then
+  echo "cannot get mapr ticket for " $i
+  echo $ret
+  ((errors++))
+fi
+
+echo errors $errors
+exit $errors

--- a/framework/src/main/java/org/apache/drill/test/framework/TestDriver.java
+++ b/framework/src/main/java/org/apache/drill/test/framework/TestDriver.java
@@ -647,6 +647,9 @@ public class TestDriver {
     Utils.updateDrillStoragePlugins(templatePath);
 */
 
+    // Run commands in before-run.sh
+    k8sStartup();
+
 /*
     String beforeRunQueryFilename = DrillTestDefaults.TEST_ROOT_DIR + "/" + cmdParam.beforeRunQueryFilename;
     LOG.info("\n> Executing init queries\n");
@@ -697,6 +700,28 @@ public class TestDriver {
 	}
 */
     Thread.sleep(1000);
+  }
+
+  private void k8sStartup()
+          throws IOException {
+
+    String command = "./before-run.sh";
+    CmdConsOut cmdConsOut;
+    LOG.info ("Executing startup commands");
+    try {
+      cmdConsOut = Utils.execCmd(command);
+      if (cmdConsOut.exitCode != 0) {
+        LOG.error("Error: Failed to execute the command " + cmdConsOut);
+        throw new RuntimeException();
+        }
+    } catch (Exception e) {
+      cmdConsOut = new CmdConsOut();
+      cmdConsOut.cmd = command;
+      cmdConsOut.consoleErr = e.getMessage();
+      LOG.error("Error: Failed to execute the command " + cmdConsOut);
+      throw new RuntimeException(e);
+    }
+
   }
   
   private void teardown() {


### PR DESCRIPTION
Add ability to run some commands before starting tests.  These commands
will always be run.
The first commands will get mapr tickets in all datafabric pods and tenantcli-0.
Thus individual tests do not need to get mapr tickets.