### PR TITLE
Update ldap tests.

### DIFF
--- a/framework/resources/Datasources/ldap/ldapfiles/ldapuser1.mfs.cat.sh
+++ b/framework/resources/Datasources/ldap/ldapfiles/ldapuser1.mfs.cat.sh
@@ -1,11 +1,41 @@
-hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser1group/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser1group/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1group/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1group/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser1group/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1group/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1group/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser1other/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser1other/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1other/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1other/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser1other/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1other/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1other/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser2group/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser2group/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2group/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2group/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser2group/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2group/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2group/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser2other/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser2other/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2other/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2other/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser2other/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2other/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2other/ldapuser2owner

--- a/framework/resources/Datasources/ldap/ldapfiles/ldapuser1.mfs.nox.sh
+++ b/framework/resources/Datasources/ldap/ldapfiles/ldapuser1.mfs.nox.sh
@@ -1,11 +1,41 @@
-hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/ldapuser2owner

--- a/framework/resources/Datasources/ldap/ldapfiles/ldapuser11.mfs.cat.sh
+++ b/framework/resources/Datasources/ldap/ldapfiles/ldapuser11.mfs.cat.sh
@@ -1,11 +1,41 @@
-hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser1group/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser1group/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1group/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1group/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser1group/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1group/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1group/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser1other/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser1other/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1other/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1other/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser1other/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1other/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1other/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser2group/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser2group/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2group/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2group/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser2group/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2group/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2group/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser2other/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser2other/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2other/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2other/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser2other/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2other/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2other/ldapuser2owner

--- a/framework/resources/Datasources/ldap/ldapfiles/ldapuser11.mfs.nox.sh
+++ b/framework/resources/Datasources/ldap/ldapfiles/ldapuser11.mfs.nox.sh
@@ -1,11 +1,41 @@
-hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/ldapuser2owner

--- a/framework/resources/Datasources/ldap/ldapfiles/ldapuser2.mfs.cat.sh
+++ b/framework/resources/Datasources/ldap/ldapfiles/ldapuser2.mfs.cat.sh
@@ -1,11 +1,41 @@
-hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser1group/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser1group/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1group/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1group/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser1group/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1group/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1group/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser1other/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser1other/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1other/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1other/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser1other/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1other/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1other/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser2group/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser2group/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2group/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2group/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser2group/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2group/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2group/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser2other/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser2other/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2other/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2other/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser2other/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2other/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2other/ldapuser2owner

--- a/framework/resources/Datasources/ldap/ldapfiles/ldapuser2.mfs.nox.sh
+++ b/framework/resources/Datasources/ldap/ldapfiles/ldapuser2.mfs.nox.sh
@@ -1,11 +1,41 @@
-hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/ldapuser2owner

--- a/framework/resources/Datasources/ldap/ldapfiles/ldapuser40.mfs.cat.sh
+++ b/framework/resources/Datasources/ldap/ldapfiles/ldapuser40.mfs.cat.sh
@@ -1,11 +1,41 @@
-hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1owner/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser1group/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser1group/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1group/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1group/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser1group/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1group/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1group/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser1other/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser1other/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1other/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1other/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser1other/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1other/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1other/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2owner/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser2group/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser2group/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2group/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2group/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser2group/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2group/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2group/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser2other/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser2other/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2other/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2other/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser2other/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2other/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2other/ldapuser2owner

--- a/framework/resources/Datasources/ldap/ldapfiles/ldapuser40.mfs.nox.sh
+++ b/framework/resources/Datasources/ldap/ldapfiles/ldapuser40.mfs.nox.sh
@@ -1,11 +1,41 @@
-hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1ownernox/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1groupnox/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser1othernox/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2ownernox/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2groupnox/ldapuser2owner
 echo
-hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/*
+hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/ldapuser1group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/ldapuser1other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/ldapuser1owner
+hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/ldapuser2group
+hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/ldapuser2other
+hadoop fs -cat /tmp/ldapfiles/ldapuser2othernox/ldapuser2owner


### PR DESCRIPTION
Access each file individually to ensure output is generated in the
expected sequence and is not interleaved.  Otherwise, error messages
from accessing one file might interleave with access to another file.