### PR TITLE
MD-6283: Refactor DRILL_CP in drill-test-framework to avoid unexpected debug logs

### DIFF
--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -9,7 +9,7 @@ if [ $? -ne 0 ]; then
 fi
 DRILL_VERSION=$(grep 'git.build.version' ${DRILL_HOME}/git.properties | tr '=' '\n' | tail -1)
 HADOOP_MAPR_VERSION=$(cat /opt/mapr/hadoop/hadoopversion)
-DRILL_CP="${DRILL_HOME}/jars/*:${DRILL_HOME}/jars/ext/*:${DRILL_HOME}/jars/3rdparty/*:${DRILL_HOME}/jars/classb/*"
+DRILL_CP="${mainDir}/jars/*"
 JDBC_DRIVER_CP="${DRILL_HOME}/jars/jdbc-driver/drill-jdbc-all-${DRILL_VERSION}.jar"
 
 maven_setup() {
@@ -17,15 +17,6 @@ maven_setup() {
   local mvn_url="https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz"
   curl "${mvn_url}" | tar -C "${mainDir}" -xz
 }
-
-if [ ! -d ./apache-maven-3.6.3 ]; then
-  maven_setup
-  M2_HOME=$(pwd)/apache-maven-3.6.3
-fi
-
-echo "Creating link on drill-distrib.conf and drill-override.conf"
-ln -s ${DRILL_HOME}/conf/drill-distrib.conf ./conf/drill-distrib.conf
-ln -s ${DRILL_HOME}/conf/drill-override.conf ./conf/drill-override.conf
 
 gen_config() {
     echo "Create drillTestConfig file..."
@@ -90,6 +81,65 @@ export PASSWORD
 EOF
 
 }
+
+update_symlinks() {
+    ln -sf ${DRILL_HOME}/jars/drill-hive-exec-shaded-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/drill-auth-mechanism-maprsasl-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/drill-common-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/drill-java-exec-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/drill-jdbc-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/drill-memory-base-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/drill-protocol-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/drill-rpc-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/drill-shaded-guava-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/vector-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/ext/zookeeper-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/classb/reflections-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/classb/javax.servlet-api-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/avatica-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/commons-codec-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/commons-collections-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/commons-configuration-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/config-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/curator-client-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/curator-framework-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/curator-recipes-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/curator-x-discovery-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/guava-shaded-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/hadoop-auth-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/hadoop-common-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/hadoop-yarn-common-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/hppc-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/jackson-annotations-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/jackson-core-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/jackson-databind-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/jetty-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/jcl-over-slf4j-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/maprfs-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/metrics-core-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/metrics-jmx-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/metrics-jvm-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/netty-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/protobuf-java-* ${mainDir}/jars/.
+    ln -sf ${DRILL_HOME}/jars/3rdparty/xml-apis-*.jar ${mainDir}/jars/.
+}
+
+if [ ! -d ./apache-maven-3.6.3 ]; then
+  maven_setup
+  M2_HOME=$(pwd)/apache-maven-3.6.3
+fi
+
+echo "Creating link on drill-distrib.conf and drill-override.conf"
+ln -sf ${DRILL_HOME}/conf/drill-distrib.conf ./conf/drill-distrib.conf
+ln -sf ${DRILL_HOME}/conf/drill-override.conf ./conf/drill-override.conf
+
+echo "Creating jars directory if not exist"
+if [ ! -d ${mainDir}/jars ]; then
+    mkdir ${mainDir}/jars
+fi
+
+echo "Creating/Updating symlinks for necessary drill's jars"
+update_symlinks
 
 if [ ! -f ./conf/drillTestConfig.properties ]; then
     gen_config


### PR DESCRIPTION
My proposal is to create a folder, in my PR I named it "jars" - but be free to suggest another name (share, etc) and place here the symlinks for all necessary drill jars. In DRILL_CP we specifying that new folder and everything working as expected.

The selected jars are from [here](https://maprdrill.atlassian.net/browse/MD-6116?focusedCommentId=206588).  I've added a few more (jetty jars) and excluded log4j-over-slf4j and guava-28.2-jre.jar.