### PR TITLE
Remove mapr dependencies

### DIFF
--- a/bin/run_tests
+++ b/bin/run_tests
@@ -31,10 +31,4 @@ done
 # and set ${JDBC_DRIVER_CP} inside conf/drillTestConfig.properties
 # java -cp conf/:${JDBC_DRIVER_CP}:framework/target/framework-1.0.0-SNAPSHOT-shaded.jar:${HADOOP_INSTALL_LOC}/lib/* org.apache.drill.test.framework.TestDriver $*
 
-# use the following line when testing apache drill JDBC driver
-if [[ $HADOOP_VERSION == *"mapr"* ]]
-then
-  java $DRILL_TEST_FRAMEWORK_JAVA_OPTS -Xss40m -cp .:conf/:${DRILL_HOME}/jars/jdbc-driver/drill-jdbc-all-${DRILL_VERSION}.jar:framework/target/framework-1.0.0-SNAPSHOT-shaded.jar -Dfs.mapr.bailout.on.library.mismatch=false -Djava.io.tmpdir=/tmp/drill/tests -Djava.security.auth.login.config=/opt/mapr/conf/mapr.login.conf -Dzookeeper.sasl.client=false org.apache.drill.test.framework.TestDriver "${ARGS[@]}"
-else
-  java $DRILL_TEST_FRAMEWORK_JAVA_OPTS -Xss40m -cp .:conf/:${DRILL_HOME}/jars/jdbc-driver/drill-jdbc-all-${DRILL_VERSION}.jar:framework/target/framework-1.0.0-SNAPSHOT-shaded.jar org.apache.drill.test.framework.TestDriver "${ARGS[@]}"
-fi
+java $DRILL_TEST_FRAMEWORK_JAVA_OPTS -Xss40m -cp .:conf/:${DRILL_HOME}/jars/jdbc-driver/drill-jdbc-all-${DRILL_VERSION}.jar:framework/target/framework-1.0.0-SNAPSHOT-shaded.jar org.apache.drill.test.framework.TestDriver "${ARGS[@]}"

--- a/conf/drillTestConfig.properties
+++ b/conf/drillTestConfig.properties
@@ -23,7 +23,7 @@ DRILL_OUTPUT_DIR=drill-output
 # Location of hadoop system drill is 
 # running in
 ########################################
-HADOOP_INSTALL_LOC=/opt/mapr
+# HADOOP_INSTALL_LOC=/opt/mapr
 
 ########################################
 # Path to the distributed system where
@@ -75,6 +75,7 @@ export PATH=.:$M2:$PATH
 
 export DRILL_VERSION=1.16.0-SNAPSHOT
 # export HADOOP_VERSION=1.0.3-mapr-3.0.2
-export HADOOP_VERSION=2.7.0-mapr-1808
+# export HADOOP_VERSION=2.7.0-mapr-1808
+export HADOOP_VERSION=2.7.6
 export USERNAME
 export PASSWORD

--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -130,16 +130,6 @@
     </dependency>
   </dependencies>
   <repositories>
-    <repository>
-      <id>mapr-releases</id>
-      <url>http://repository.mapr.com/maven/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
   </repositories>
   <build>
     <plugins>


### PR DESCRIPTION
Remove mapr dependencies so drill-test-framework can be built without them. This version of drill-test-framework for Picasso does not use mapr.